### PR TITLE
fix-delete-room-permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install
     export HUBOT_RSS_PRINTERROR=false   # print error message (default is "true")
     export HUBOT_RSS_IRCCOLORS=true     # use IRC color message (default is "false")
     export HUBOT_RSS_LIMIT_ON_ADD=false # limit printing entries on add new feed. (default is 5)
-    export HUBOT_RSS_DUMP_USERS=""      # limit dump to special user (eg. "user1,user2")
+    export HUBOT_RSS_DUMP_USERS=""      # limit dump to special user (list without spaces eg. "user1,user2")
 
 Usage
 -----
@@ -56,12 +56,12 @@ Usage
 ### delete
 
     hubot rss delete https://github.com/Flipez.atom
-    hubot rss delete #room_name
+    hubot rss delete #room_name (only within the room or for users in HUBOT_RSS_DUMP_USERS list)
 
 ### list
 
     hubot rss list
-    hubot rss dump
+    hubot rss dump (only for users in HUBOT_RSS_DUMP_USERS list)
 
 
 Test

--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -165,11 +165,15 @@ module.exports = class RSSChecker extends events.EventEmitter
       else
         return reject "#{url} is not registered"
 
-  deleteRoom: (name) ->
+  deleteRoom: (name, myname, myuser) ->
     new Promise (resolve, reject) =>
-      rooms = @getAllFeeds() or {}
-      unless rooms.hasOwnProperty name
-        return reject "room ##{name} is not exists"
-      delete rooms[name]
-      @robot.brain.set 'feeds', rooms
-      resolve "deleted room ##{name}"
+      if ( name is myname || myuser in process.env.HUBOT_RSS_DUMP_USERS.split "," )
+        rooms = @getAllFeeds() or {}
+        unless rooms.hasOwnProperty name
+          return reject "room ##{name} is not exists"
+        delete rooms[name]
+        @robot.brain.set 'feeds', rooms
+        resolve "deleted room ##{name}"
+      else
+        return reject "not allowed to delete room ##{name} from outside"
+        

--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -157,7 +157,7 @@ module.exports = (robot) ->
   robot.respond /rss\s+delete\s+#([^\s]+)$/im, (msg) ->
     room = msg.match[1].trim()
     logger.info "delete ##{room}"
-    checker.deleteRoom room
+    checker.deleteRoom(room, msg.message.room, msg.message.user.name)
     .then (res) ->
       msg.send res
     .catch (err) ->


### PR DESCRIPTION
Hi Robert,

this is an first idea to restrict `rss delete #room` only within a room itself or to users in `HUBOT_RSS_DUMP_USERS` list.

Why that? At the moment it is possible for any user to delete any `rss delete #room`. We offer several public readonly channels with rss feeds in Rocket.Chat. Even though a user can't post messages to those readonly channels and and send bot commands, it's possible to remove the complete "rss room" from another channel or private room. Furthermore it is possible to delete rss rooms in other user's private rooms (assumed you know the room name). Therefore I think this is a quick fix to prevent global `rss delete #room` to anybody.

Ciao
Marcus