### PR TITLE
feature printmarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Install
     export HUBOT_RSS_USERAGENT=hubot    # (default is "hubot-rss-reader/#{package_version}")
     export HUBOT_RSS_PRINTSUMMARY=true  # print summary (default is "true")
     export HUBOT_RSS_PRINTIMAGE=false   # print image in summary (default is "true")
+    export HUBOT_RSS_PRINTMARKDOWN=true # use markdown message (default is "false")
     export HUBOT_RSS_PRINTERROR=false   # print error message (default is "true")
     export HUBOT_RSS_IRCCOLORS=true     # use IRC color message (default is "false")
     export HUBOT_RSS_LIMIT_ON_ADD=false # limit printing entries on add new feed. (default is 5)

--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -82,10 +82,12 @@ module.exports = class RSSChecker extends events.EventEmitter
           summary: cleanup_summary entities.decode(chunk.summary or chunk.description or '')
           feed:
             url: args.url
-            title: entities.decode(feedparser.meta.title or '')
+            title: entities.decode(feedparser.meta.title or 'visit feed')
           toString: ->
             if process.env.HUBOT_RSS_IRCCOLORS is "true"
               s = "#{IrcColor.pink(process.env.HUBOT_RSS_HEADER)} #{@title} #{IrcColor.purple('- ['+@feed.title+']')}\n#{IrcColor.lightgrey.underline(@url)}"
+            else if process.env.HUBOT_RSS_PRINTMARKDOWN is "true"
+              s = "#{process.env.HUBOT_RSS_HEADER} *#{@title} - [[#{@feed.title}](#{@url})]*"
             else
               s = "#{process.env.HUBOT_RSS_HEADER} #{@title} - [#{@feed.title}]\n#{@url}"
 

--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -21,15 +21,16 @@ FindRSS    = Promise.promisify require 'find-rss'
 
 ## config
 package_json = require path.join __dirname, '../package.json'
-process.env.HUBOT_RSS_INTERVAL     ||= 60*10  # 10 minutes
-process.env.HUBOT_RSS_HEADER       ||= ':sushi:'
-process.env.HUBOT_RSS_USERAGENT    ||= "hubot-rss-rolf/#{package_json.version}"
-process.env.HUBOT_RSS_PRINTSUMMARY ||= "true"
-process.env.HUBOT_RSS_PRINTIMAGE   ||= "true"
-process.env.HUBOT_RSS_PRINTERROR   ||= "true"
-process.env.HUBOT_RSS_IRCCOLORS    ||= "false"
-process.env.HUBOT_RSS_LIMIT_ON_ADD ||= 5
-process.env.HUBOT_RSS_DUMP_USERS   ||= ""
+process.env.HUBOT_RSS_INTERVAL      ||= 60*10  # 10 minutes
+process.env.HUBOT_RSS_HEADER        ||= ':sushi:'
+process.env.HUBOT_RSS_USERAGENT     ||= "hubot-rss-rolf/#{package_json.version}"
+process.env.HUBOT_RSS_PRINTSUMMARY  ||= "true"
+process.env.HUBOT_RSS_PRINTIMAGE    ||= "true"
+process.env.HUBOT_RSS_PRINTMARKDOWN ||= "false"
+process.env.HUBOT_RSS_PRINTERROR    ||= "true"
+process.env.HUBOT_RSS_IRCCOLORS     ||= "false"
+process.env.HUBOT_RSS_LIMIT_ON_ADD  ||= 5
+process.env.HUBOT_RSS_DUMP_USERS    ||= ""
 
 module.exports = (robot) ->
 


### PR DESCRIPTION


Hi Robert,

this is a new feature to markdown the feed header. It "cleans up" messages and makes posts more clear. To turn on set env `HUBOT_RSS_PRINTMARKDOWN=true`

Ciao
Marcus
 
![hc](https://user-images.githubusercontent.com/8544984/30184664-13a4397c-941f-11e7-85a3-79ec2d09a146.jpg)
