### PR TITLE
[Feature] dump markdown

### DIFF
--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -178,6 +178,9 @@ module.exports = (robot) ->
   robot.respond /rss dump$/i, (msg) ->
     if msg.message.user.name in process.env.HUBOT_RSS_DUMP_USERS.split ","
       feeds = checker.getAllFeeds()
-      msg.send JSON.stringify feeds, null, 2
+      if process.env.HUBOT_RSS_PRINTMARKDOWN is "true"
+        msg.send "```#{JSON.stringify feeds, null, 2}```"
+       else
+        msg.send JSON.stringify feeds, null, 2
     else
       msg.send "not allowed"


### PR DESCRIPTION
Hi Robert,

this is a new feature to print `rss dump` as markdown; makes it more readable.

![markdown_dump](https://user-images.githubusercontent.com/8544984/30277469-2fe7d63e-9708-11e7-8a6d-79a477031fc9.jpg)

Ciao!
Marcus