### PR TITLE
Pinning html-entities to version 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "*",
     "feedparser": "*",
     "find-rss": "*",
-    "html-entities": "*",
+    "html-entities": "1.2.1",
     "iconv": "*",
     "irc-colors": "^1.1.1",
     "lodash": "*",


### PR DESCRIPTION
Pinning html-entities to version 1.2.1 to avoid compatibility issues. Fixes #18 